### PR TITLE
feat: Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "FingerprintJS",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(
+            name: "FingerprintJS",
+            targets: ["FingerprintJS"]
+        ),
+    ],
+    targets: [
+        .target(name: "FingerprintJS"),
+        .testTarget(
+            name: "FingerprintJSTests",
+            dependencies: ["FingerprintJS"],
+            path: "./Sources/FingerprintJSTests"
+        )
+    ]
+)

--- a/Sources/FingerprintJSTests/Mocks/MockHashingFunction.swift
+++ b/Sources/FingerprintJSTests/Mocks/MockHashingFunction.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Petr Palata on 23.03.2022.
 //
-
+import Foundation
 @testable import FingerprintJS
 
 class MockFingerprintFunction: FingerprintFunction {


### PR DESCRIPTION
Adds SPM support. If you want to add CI for the SPM stuff, I ran this locally in the repo root to validate I set things up correctly:
```
xcodebuild test \
    -scheme FingerprintJS \
    -destination 'platform=iOS Simulator,name=iPhone 13'
```

Also needed to add the Foundation import, otherwise the tests fail to compile under SPM.