### PR TITLE
Extract script phase for formatting code to separate script file

### DIFF
--- a/Scripts/Commons/common.sh
+++ b/Scripts/Commons/common.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#####################
+#     CONSTANTS     #
+#####################
+
+readonly ERROR_HOMEBREW_NOT_INSTALLED=$(cat << MSG
+error: Homebrew not installed. See https://brew.sh/ for installation instructions.
+MSG
+)
+
+readonly ERROR_SWIFTFORMAT_CMD_MISSING=$(cat << MSG
+error: 'swift-format' command not found.
+MSG
+)
+
+#####################
+#     FUNCTIONS     #
+#####################
+
+function command_exists() {
+    if [[ -z $1 ]]
+    then
+        return 1
+    fi
+    if ! command -v $1 &>/dev/null
+    then
+        return 1
+    fi
+
+    return 0
+}
+
+function setup_homebrew() {
+    local -r homebrew_arm_path="/opt/homebrew/bin/brew"
+    local -r homebrew_x86_path="/usr/local/bin/brew"
+
+    if [[ ! -f "$homebrew_arm_path" ]]
+    then
+        if [[ ! -f "$homebrew_x86_path" ]]
+        then
+            return 1
+        fi
+
+        return 0
+    fi
+
+    # On Apple Silicon machines, Homebrew requires additional setup
+    eval "$("$homebrew_arm_path" shellenv)"
+}

--- a/Scripts/format_code.sh
+++ b/Scripts/format_code.sh
@@ -2,9 +2,11 @@
 
 set -Eeuo pipefail
 
-source "$(dirname "$0")"/Commons/common.sh
+readonly SCRIPT_REL_PATH="$(dirname "$0")"
 
-readonly SCRIPT_ABS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
+source "$SCRIPT_REL_PATH"/Commons/common.sh
+
+readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
 
 readonly PROJECT_ROOT_PATH="$SCRIPT_ABS_PATH/.."
 

--- a/Scripts/format_code.sh
+++ b/Scripts/format_code.sh
@@ -22,8 +22,8 @@ fi
 
 cd "$PROJECT_ROOT_PATH"
 
-swift-format lint \
+swift-format format \
         --configuration ./.swift-format \
+        --in-place \
         --recursive \
-        --strict \
         ./Package.swift ./Sources

--- a/Scripts/lint_code.sh
+++ b/Scripts/lint_code.sh
@@ -2,9 +2,11 @@
 
 set -Eeuo pipefail
 
-source "$(dirname "$0")"/Commons/common.sh
+readonly SCRIPT_REL_PATH="$(dirname "$0")"
 
-readonly SCRIPT_ABS_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)"
+source "$SCRIPT_REL_PATH"/Commons/common.sh
+
+readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
 
 readonly PROJECT_ROOT_PATH="$SCRIPT_ABS_PATH/.."
 

--- a/Sources/FingerprintJS.xcodeproj/project.pbxproj
+++ b/Sources/FingerprintJS.xcodeproj/project.pbxproj
@@ -335,7 +335,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6A82A18C27D65DB4007C023F /* Build configuration list for PBXNativeTarget "FingerprintJS" */;
 			buildPhases = (
-				6A58225A27F0D885002EA33E /* Format Code */,
 				6A82A17527D65DB4007C023F /* Headers */,
 				6A82A17627D65DB4007C023F /* Sources */,
 				6A82A17727D65DB4007C023F /* Frameworks */,
@@ -422,28 +421,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		6A58225A27F0D885002EA33E /* Format Code */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = "Format Code";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e\n\n\"${PROJECT_DIR}/../Scripts/format_code.sh\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6A82A17627D65DB4007C023F /* Sources */ = {

--- a/Sources/FingerprintJS.xcodeproj/project.pbxproj
+++ b/Sources/FingerprintJS.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6A82A18C27D65DB4007C023F /* Build configuration list for PBXNativeTarget "FingerprintJS" */;
 			buildPhases = (
-				6A58225A27F0D885002EA33E /* ShellScript */,
+				6A58225A27F0D885002EA33E /* Format Code */,
 				6A82A17527D65DB4007C023F /* Headers */,
 				6A82A17627D65DB4007C023F /* Sources */,
 				6A82A17727D65DB4007C023F /* Frameworks */,
@@ -424,8 +424,9 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		6A58225A27F0D885002EA33E /* ShellScript */ = {
+		6A58225A27F0D885002EA33E /* Format Code */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -433,13 +434,14 @@
 			);
 			inputPaths = (
 			);
+			name = "Format Code";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export PATH=$PATH:/opt/homebrew/bin\n\nif which swift-format >/dev/null; then\n     swift-format format \\\n        --configuration ${PROJECT_DIR}/../.swift-format \\\n        --in-place \\\n        --recursive \\\n        ${PROJECT_DIR}\nelse\n    echo \"warning: swift-format not installed\"\nfi\n";
+			shellScript = "set -e\n\n\"${PROJECT_DIR}/../Scripts/format_code.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The rationale behind this change was to ease the developers from the error-prone process of reviewing changes made in `pbxproj` file, where the configuration of build phases is stored.

In addition, this commit fixes Xcode warnings related to misuse of script phase's "Based on dependency analysis" option.