### PR TITLE
Pre-commit hook ensuring correct code formatting with `swift-format`

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,13 +11,12 @@ function changed_swift_files() {
 
 changed_swift_files | while read swift_file;
 do
-    swift-format format \
-        --in-place \
-        "${swift_file}";
+    ./Scripts/format_code.sh "${swift_file}"
 
-    if [[ $? -ne 0 ]]; then
+    if [[ $? -ne 0 ]]
+    then
         echo "Failed to process Swift file: ${swift_file}. Pre-commit hook failed"
-        exit 1;
+        exit 1
     fi
 
     git add "${swift_file}";

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,23 +1,21 @@
 #!/bin/bash
 
-readonly SWIFT_FILE_REGEX="\(.*\).swift$"
-
 function changed_swift_files() {
     git diff \
         --diff-filter=d \
         --staged \
-        --name-only | grep -e "$SWIFT_FILE_REGEX"
+        --name-only \
+        -- '*.swift' |
+        awk '{ print "\""$0"\""; }' |
+        tr '\n' ' '
 }
 
-changed_swift_files | while read swift_file;
-do
-    ./Scripts/format_code.sh "${swift_file}"
+SWIFT_FILES="$(changed_swift_files)"
 
-    if [[ $? -ne 0 ]]
-    then
-        echo "Failed to process Swift file: ${swift_file}. Pre-commit hook failed"
-        exit 1
-    fi
+if ! ./Scripts/format_code.sh "${SWIFT_FILES[@]}"
+then
+    echo "Pre-commit hook failed" 1>&2
+    exit 1
+fi
 
-    git add "${swift_file}";
-done
+echo "${SWIFT_FILES[@]}" | xargs git add

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+readonly SWIFT_FILE_REGEX="\(.*\).swift$"
+
+function changed_swift_files() {
+    git diff \
+        --diff-filter=d \
+        --staged \
+        --name-only | grep -e "$SWIFT_FILE_REGEX"
+}
+
+changed_swift_files | while read swift_file;
+do
+    swift-format format \
+        --in-place \
+        "${swift_file}";
+
+    if [[ $? -ne 0 ]]; then
+        echo "Failed to process Swift file: ${swift_file}. Pre-commit hook failed"
+        exit 1;
+    fi
+
+    git add "${swift_file}";
+done

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help lint tests
+.PHONY: help lint tests environment
 
-ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-GITHOOKS_DIR="$(ROOT_DIR)/.githooks/"
+ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+GITHOOKS_DIR := "$(ROOT_DIR)/.githooks"
 
 help:
 	@cat $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 .PHONY: help lint tests
 
+ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+GITHOOKS_DIR="$(ROOT_DIR)/.githooks/"
+
 help:
 	@cat $(MAKEFILE_LIST)
 
@@ -10,3 +13,6 @@ lint:
 
 tests:
 	@./Scripts/run_tests.sh
+
+environment:
+	git config core.hooksPath $(GITHOOKS_DIR)

--- a/Scripts/format_code.sh
+++ b/Scripts/format_code.sh
@@ -12,29 +12,27 @@ readonly PROJECT_ROOT_PATH="$SCRIPT_ABS_PATH/.."
 
 if ! setup_homebrew
 then
-    echo "$ERROR_HOMEBREW_NOT_INSTALLED"
+    echo "$ERROR_HOMEBREW_NOT_INSTALLED" 1>&2
     exit 1
 fi
 
 if ! command_exists "swift-format"
 then
-    echo "$ERROR_SWIFTFORMAT_CMD_MISSING"
+    echo "$ERROR_SWIFTFORMAT_CMD_MISSING" 1>&2
     exit 1
 fi
 
 cd "$PROJECT_ROOT_PATH"
 
-if [[ $# -eq 0 ]]
+SWIFT_FORMAT_INPUT_FILENAMES="./Package.swift ./Sources"
+
+if [[ $# -ne 0 ]]
 then
-    swift-format format \
-        --configuration ./.swift-format \
-        --in-place \
-        --recursive \
-        ./Package.swift ./Sources
-else
-    readonly SWIFT_FILE=$1
-    swift-format format \
-        --configuration ./.swift-format \
-        --in-place \
-        "${SWIFT_FILE}"
+    SWIFT_FORMAT_INPUT_FILENAMES="$*"
 fi
+
+echo "${SWIFT_FORMAT_INPUT_FILENAMES[@]}" | xargs \
+        swift-format format \
+        --configuration ./.swift-format \
+        --in-place \
+        --recursive

--- a/Scripts/format_code.sh
+++ b/Scripts/format_code.sh
@@ -24,8 +24,17 @@ fi
 
 cd "$PROJECT_ROOT_PATH"
 
-swift-format format \
+if [[ $# -eq 0 ]]
+then
+    swift-format format \
         --configuration ./.swift-format \
         --in-place \
         --recursive \
         ./Package.swift ./Sources
+else
+    readonly SWIFT_FILE=$1
+    swift-format format \
+        --configuration ./.swift-format \
+        --in-place \
+        "${SWIFT_FILE}"
+fi


### PR DESCRIPTION
Reuses existing `format_code.sh` script and adds parameters that allows to run in on a single file (provided through a command line parameter). Includes the `pre-commit` hook script and environment setup in `Makefile` that sets the correct path to our custom hooks directory.