### PR TITLE
Restore `Lint Code` build phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 	@cat $(MAKEFILE_LIST)
 
 lint:
-	@./Scripts/lint_code.sh
+	@./Scripts/lint_code.sh --strict
 
 tests:
 	@./Scripts/run_tests.sh

--- a/Scripts/Commons/common.sh
+++ b/Scripts/Commons/common.sh
@@ -9,8 +9,8 @@ error: Homebrew not installed. See https://brew.sh/ for installation instruction
 MSG
 )
 
-readonly ERROR_SWIFTFORMAT_CMD_MISSING=$(cat << MSG
-error: 'swift-format' command not found.
+readonly MSG_SWIFT_FORMAT_CMD_MISSING=$(cat << MSG
+'swift-format' command not found.
 MSG
 )
 

--- a/Scripts/format_code.sh
+++ b/Scripts/format_code.sh
@@ -3,10 +3,9 @@
 set -Eeuo pipefail
 
 readonly SCRIPT_REL_PATH="$(dirname "$0")"
+readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
 
 source "$SCRIPT_REL_PATH"/Commons/common.sh
-
-readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
 
 readonly PROJECT_ROOT_PATH="$SCRIPT_ABS_PATH/.."
 
@@ -18,7 +17,7 @@ fi
 
 if ! command_exists "swift-format"
 then
-    echo "$ERROR_SWIFTFORMAT_CMD_MISSING" 1>&2
+    echo "error: $MSG_SWIFT_FORMAT_CMD_MISSING" 1>&2
     exit 1
 fi
 

--- a/Scripts/lint_code.sh
+++ b/Scripts/lint_code.sh
@@ -3,29 +3,72 @@
 set -Eeuo pipefail
 
 readonly SCRIPT_REL_PATH="$(dirname "$0")"
+readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
 
 source "$SCRIPT_REL_PATH"/Commons/common.sh
 
-readonly SCRIPT_ABS_PATH="$(cd "$SCRIPT_REL_PATH" &>/dev/null && pwd -P)"
+readonly OPTION_STRICT="--strict"
 
 readonly PROJECT_ROOT_PATH="$SCRIPT_ABS_PATH/.."
 
+readonly SWIFT_FORMAT_CONFIG_PATH="./.swift-format"
+readonly SWIFT_FORMAT_INPUT_FILENAMES="./Package.swift ./Sources"
+
+STRICT_MODE=false
+
+function swift_format_missing() {
+    if [[ "$STRICT_MODE" == true ]]
+    then
+        echo "error: $MSG_SWIFT_FORMAT_CMD_MISSING" 1>&2
+        exit 1
+    else
+        echo "warning: $MSG_SWIFT_FORMAT_CMD_MISSING"
+        exit 0
+    fi
+}
+
+function swift_format_lint() {
+    if [[ "$STRICT_MODE" == true ]]
+    then
+        swift-format lint \
+                --configuration "$SWIFT_FORMAT_CONFIG_PATH" \
+                --recursive \
+                --strict \
+                $SWIFT_FORMAT_INPUT_FILENAMES
+    else
+        swift-format lint \
+                --configuration "$SWIFT_FORMAT_CONFIG_PATH" \
+                --recursive \
+                $SWIFT_FORMAT_INPUT_FILENAMES
+    fi
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    "$OPTION_STRICT")
+        shift
+        STRICT_MODE=true
+        ;;
+    *)
+        break
+        ;;
+esac
+done
+
 if ! setup_homebrew
 then
-    echo "$ERROR_HOMEBREW_NOT_INSTALLED"
+    echo "$ERROR_HOMEBREW_NOT_INSTALLED" 1>&2
     exit 1
 fi
 
 if ! command_exists "swift-format"
 then
-    echo "$ERROR_SWIFTFORMAT_CMD_MISSING"
-    exit 1
+    swift_format_missing
 fi
 
 cd "$PROJECT_ROOT_PATH"
 
-swift-format lint \
-        --configuration ./.swift-format \
-        --recursive \
-        --strict \
-        ./Package.swift ./Sources
+swift_format_lint

--- a/Sources/FingerprintJS.xcodeproj/project.pbxproj
+++ b/Sources/FingerprintJS.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 			buildConfigurationList = 6A82A18C27D65DB4007C023F /* Build configuration list for PBXNativeTarget "FingerprintJS" */;
 			buildPhases = (
 				6A82A17527D65DB4007C023F /* Headers */,
+				159E0BB92937B7C800E2C38A /* Lint Code */,
 				6A82A17627D65DB4007C023F /* Sources */,
 				6A82A17727D65DB4007C023F /* Frameworks */,
 				6A82A17827D65DB4007C023F /* Resources */,
@@ -421,6 +422,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		159E0BB92937B7C800E2C38A /* Lint Code */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Lint Code";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\n\n\"${PROJECT_DIR}/../Scripts/lint_code.sh\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		6A82A17627D65DB4007C023F /* Sources */ = {


### PR DESCRIPTION
The `lint_code.sh` script can now be run in one of the two modes:
non-strict (default) or strict mode. The strict mode can be activated
by suppling `--strict` option, which causes the script to report the 
lack of `swift-format` command as an error instead of a warning. 
Also, when run in strict mode, the script passes `--strict` option to
`swift-format` tool to make it fail on lint warnings.

The `Lint Code` Xcode build phase runs `lint_code.sh` script in
non-strict mode, whereas `make lint` runs the same script with strict
mode enabled.