### PR TITLE
Add `CellularNetworkInfoHarvester` for gathering cellular network info

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -5,7 +5,7 @@
   "indentation" : {
     "spaces" : 4
   },
-  "indentConditionalCompilationBlocks" : true,
+  "indentConditionalCompilationBlocks" : false,
   "indentSwitchCaseLabels" : false,
   "lineBreakAroundMultilineExpressionChainComponents" : false,
   "lineBreakBeforeControlFlowKeywords" : false,

--- a/Sources/FingerprintJS.xcodeproj/project.pbxproj
+++ b/Sources/FingerprintJS.xcodeproj/project.pbxproj
@@ -21,6 +21,12 @@
 		159E0BCB293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BCA293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift */; };
 		159E0BCD293F7A7900E2C38A /* ScreenInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BCC293F7A7900E2C38A /* ScreenInfoProviding.swift */; };
 		159E0BCF293FA8F400E2C38A /* DeviceIdentificationInfoProvidingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BCE293FA8F400E2C38A /* DeviceIdentificationInfoProvidingSpy.swift */; };
+		159E0BD32940D35B00E2C38A /* CellularNetworkInfoHarvester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BD22940D35B00E2C38A /* CellularNetworkInfoHarvester.swift */; };
+		159E0BD52940D41600E2C38A /* CarrierInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BD42940D41600E2C38A /* CarrierInfoProviding.swift */; };
+		159E0BD72940D66600E2C38A /* CellularServiceInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BD62940D66600E2C38A /* CellularServiceInfoProviding.swift */; };
+		159E0BD92940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BD82940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift */; };
+		159E0BDB294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BDA294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift */; };
+		159E0BDD294108E900E2C38A /* CarrierInfoProvidingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BDC294108E900E2C38A /* CarrierInfoProvidingSpy.swift */; };
 		6A1D11412809DBDE00566F75 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D11402809DBDE00566F75 /* DeviceInfo.swift */; };
 		6A1D1143280F1B6600566F75 /* DeviceInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D1142280F1B6600566F75 /* DeviceInfoProvider.swift */; };
 		6A23866328042DFB002D09F3 /* DocumentsDirectoryAttributesProvidingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A23866228042DFB002D09F3 /* DocumentsDirectoryAttributesProvidingMock.swift */; };
@@ -85,6 +91,12 @@
 		159E0BCA293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentificationInfoProviding.swift; sourceTree = "<group>"; };
 		159E0BCC293F7A7900E2C38A /* ScreenInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenInfoProviding.swift; sourceTree = "<group>"; };
 		159E0BCE293FA8F400E2C38A /* DeviceIdentificationInfoProvidingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIdentificationInfoProvidingSpy.swift; sourceTree = "<group>"; };
+		159E0BD22940D35B00E2C38A /* CellularNetworkInfoHarvester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularNetworkInfoHarvester.swift; sourceTree = "<group>"; };
+		159E0BD42940D41600E2C38A /* CarrierInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarrierInfoProviding.swift; sourceTree = "<group>"; };
+		159E0BD62940D66600E2C38A /* CellularServiceInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularServiceInfoProviding.swift; sourceTree = "<group>"; };
+		159E0BD82940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularNetworkInfoHarvesterTests.swift; sourceTree = "<group>"; };
+		159E0BDA294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularServiceInfoProvidingSpy.swift; sourceTree = "<group>"; };
+		159E0BDC294108E900E2C38A /* CarrierInfoProvidingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarrierInfoProvidingSpy.swift; sourceTree = "<group>"; };
 		6A1D11402809DBDE00566F75 /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
 		6A1D1142280F1B6600566F75 /* DeviceInfoProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfoProvider.swift; sourceTree = "<group>"; };
 		6A23866228042DFB002D09F3 /* DocumentsDirectoryAttributesProvidingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentsDirectoryAttributesProvidingMock.swift; sourceTree = "<group>"; };
@@ -179,6 +191,8 @@
 				159E0BC0293A6C6F00E2C38A /* TimeZoneInfoProvidableSpy.swift */,
 				159E0BB5292D19B700E2C38A /* UserInterfaceTraitsProvidableSpy.swift */,
 				159E0BCE293FA8F400E2C38A /* DeviceIdentificationInfoProvidingSpy.swift */,
+				159E0BDA294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift */,
+				159E0BDC294108E900E2C38A /* CarrierInfoProvidingSpy.swift */,
 			);
 			path = Spies;
 			sourceTree = "<group>";
@@ -215,6 +229,24 @@
 				159E0BC8293F79B000E2C38A /* CPUInfoProviding.swift */,
 				159E0BCA293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift */,
 				159E0BCC293F7A7900E2C38A /* ScreenInfoProviding.swift */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		159E0BD02940D2FD00E2C38A /* CellularNetworkInfoHarvester */ = {
+			isa = PBXGroup;
+			children = (
+				159E0BD12940D34700E2C38A /* Providers */,
+				159E0BD22940D35B00E2C38A /* CellularNetworkInfoHarvester.swift */,
+			);
+			path = CellularNetworkInfoHarvester;
+			sourceTree = "<group>";
+		};
+		159E0BD12940D34700E2C38A /* Providers */ = {
+			isa = PBXGroup;
+			children = (
+				159E0BD42940D41600E2C38A /* CarrierInfoProviding.swift */,
+				159E0BD62940D66600E2C38A /* CellularServiceInfoProviding.swift */,
 			);
 			path = Providers;
 			sourceTree = "<group>";
@@ -296,6 +328,7 @@
 		6A82A19827D76BFE007C023F /* Harvesters */ = {
 			isa = PBXGroup;
 			children = (
+				159E0BD02940D2FD00E2C38A /* CellularNetworkInfoHarvester */,
 				159E0BBC293A5DB100E2C38A /* OSInfoHarvester */,
 				159E0BC6293F795E00E2C38A /* HardwareInfoHarvester */,
 				159E0BAF292D17E500E2C38A /* AppInfoHarvester */,
@@ -367,6 +400,7 @@
 				6A3BB82828058B4900D2EBB9 /* IdentifierHarvesterTests.swift */,
 				6A3BB826280588FD00D2EBB9 /* OSInfoHarvesterTests.swift */,
 				6A44A31828CF8FAF0026DCD8 /* SHA256HashingFunctionTests.swift */,
+				159E0BD82940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -510,6 +544,7 @@
 				6A9B7CB227E7AA8E002B9939 /* DeviceInfoTreeProvider.swift in Sources */,
 				6A1D1143280F1B6600566F75 /* DeviceInfoProvider.swift in Sources */,
 				6A9B7CBA27E7B3D4002B9939 /* FingerprintTreeCalculator.swift in Sources */,
+				159E0BD72940D66600E2C38A /* CellularServiceInfoProviding.swift in Sources */,
 				6A9B7CB627E7AC55002B9939 /* CGSize+CustomStringConvertible.swift in Sources */,
 				6A9B7CB027E36F66002B9939 /* CompoundTreeBuilder.swift in Sources */,
 				6A82A1A027D79618007C023F /* SystemControlFlag.swift in Sources */,
@@ -520,6 +555,7 @@
 				6AC362AE28001E7D00C4768A /* FileManager+DocumentsDirectoryAttributesProviding.swift in Sources */,
 				6A82A19E27D775AF007C023F /* SystemControl.swift in Sources */,
 				6A82A1B327DB5941007C023F /* OSInfoHarvester.swift in Sources */,
+				159E0BD32940D35B00E2C38A /* CellularNetworkInfoHarvester.swift in Sources */,
 				6A82A1A627D89817007C023F /* IdentifierStorable.swift in Sources */,
 				159E0BBF293A5DE500E2C38A /* TimeZoneProvidable.swift in Sources */,
 				6A9B7CA727E207A9002B9939 /* SystemControlError.swift in Sources */,
@@ -533,6 +569,7 @@
 				6A9B7CAE27E220F1002B9939 /* Fingerprinter.swift in Sources */,
 				6A82A19B27D76CD6007C023F /* HardwareInfoHarvester.swift in Sources */,
 				159E0BCB293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift in Sources */,
+				159E0BD52940D41600E2C38A /* CarrierInfoProviding.swift in Sources */,
 				6A82A1A427D897F2007C023F /* KeychainIdentifierStorage.swift in Sources */,
 				6A9B7CAA27E214C5002B9939 /* FingerprinterFactory.swift in Sources */,
 				159E0BC9293F79B000E2C38A /* CPUInfoProviding.swift in Sources */,
@@ -548,10 +585,13 @@
 				6A3BB827280588FD00D2EBB9 /* OSInfoHarvesterTests.swift in Sources */,
 				6A3BB82928058B4900D2EBB9 /* IdentifierHarvesterTests.swift in Sources */,
 				6AB7146427EB65B1004BBCF3 /* MockHashingFunction.swift in Sources */,
+				159E0BD92940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift in Sources */,
 				6AC362AB280013E200C4768A /* HardwareInfoHarvesterTests.swift in Sources */,
 				159E0BC1293A6C6F00E2C38A /* TimeZoneInfoProvidableSpy.swift in Sources */,
+				159E0BDB294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift in Sources */,
 				6AC362B228042B7C00C4768A /* SystemControlMock.swift in Sources */,
 				159E0BAE292D149700E2C38A /* AppInfoHarvesterTests.swift in Sources */,
+				159E0BDD294108E900E2C38A /* CarrierInfoProvidingSpy.swift in Sources */,
 				6A23866328042DFB002D09F3 /* DocumentsDirectoryAttributesProvidingMock.swift in Sources */,
 				159E0BC5293E4FF900E2C38A /* LocaleInfoProvidableSpy.swift in Sources */,
 				6AB7146127EB612D004BBCF3 /* FingerprintTreeCalculatorTests.swift in Sources */,

--- a/Sources/FingerprintJS/Fingerprints/CompoundTreeBuilder.swift
+++ b/Sources/FingerprintJS/Fingerprints/CompoundTreeBuilder.swift
@@ -2,12 +2,16 @@ struct CompoundTreeBuilder {
     private let providers: [DeviceInfoTreeProvider]
 
     init() {
-        self.init(providers: [
+        var providers: [DeviceInfoTreeProvider] = [
             AppInfoHarvester(),
             HardwareInfoHarvester(),
             OSInfoHarvester(),
             IdentifierHarvester(),
-        ])
+        ]
+        #if os(iOS)
+        providers.append(CellularNetworkInfoHarvester())
+        #endif
+        self.init(providers: providers)
     }
 
     init(providers: [DeviceInfoTreeProvider]) {

--- a/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
+++ b/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
@@ -186,3 +186,34 @@ extension OSInfoHarvester: DeviceInfoTreeProvider {
         ]
     }
 }
+
+#if os(iOS)
+extension CellularNetworkInfoHarvester: DeviceInfoTreeProvider {
+    func buildTree(_ configuration: Configuration) -> DeviceInfoItem {
+        return DeviceInfoItem(
+            label: "Cellular Network",
+            value: .category,
+            children: itemsForVersion(configuration.version)
+        )
+    }
+
+    var versionedItems: [VersionedInfoItem] {
+        return [
+            VersionedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Mobile country codes",
+                    value: .info(mobileCountryCodes.description)
+                ),
+                versions: []
+            ),
+            VersionedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Mobile network codes",
+                    value: .info(mobileNetworkCodes.description)
+                ),
+                versions: []
+            ),
+        ]
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
@@ -1,0 +1,43 @@
+#if canImport(CoreTelephony)
+import CoreTelephony
+#endif
+
+@available(tvOS, unavailable)
+protocol CellularNetworkInfoHarvesting {
+    var mobileCountryCodes: [String] { get }
+    var mobileNetworkCodes: [String] { get }
+}
+
+@available(tvOS, unavailable)
+struct CellularNetworkInfoHarvester {
+
+    private let cellularServiceInfoProvider: CellularServiceInfoProviding
+
+    init(cellularServiceInfoProvider: CellularServiceInfoProviding) {
+        self.cellularServiceInfoProvider = cellularServiceInfoProvider
+    }
+}
+
+#if os(iOS)
+extension CellularNetworkInfoHarvester {
+
+    init() {
+        self.init(cellularServiceInfoProvider: CTTelephonyNetworkInfo())
+    }
+}
+
+extension CellularNetworkInfoHarvester: CellularNetworkInfoHarvesting {
+
+    var mobileCountryCodes: [String] {
+        cellularServiceInfoProvider
+            .cellularProviders
+            .compactMap(\.mobileCountryCode)
+    }
+
+    var mobileNetworkCodes: [String] {
+        cellularServiceInfoProvider
+            .cellularProviders
+            .compactMap(\.mobileNetworkCode)
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
@@ -32,12 +32,14 @@ extension CellularNetworkInfoHarvester: CellularNetworkInfoHarvesting {
         cellularServiceInfoProvider
             .cellularProviders
             .compactMap(\.mobileCountryCode)
+            .sorted()
     }
 
     var mobileNetworkCodes: [String] {
         cellularServiceInfoProvider
             .cellularProviders
             .compactMap(\.mobileNetworkCode)
+            .sorted()
     }
 }
 #endif

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CarrierInfoProviding.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CarrierInfoProviding.swift
@@ -1,0 +1,13 @@
+#if canImport(CoreTelephony)
+import CoreTelephony
+#endif
+
+@available(tvOS, unavailable)
+protocol CarrierInfoProviding {
+    var mobileCountryCode: String? { get }
+    var mobileNetworkCode: String? { get }
+}
+
+#if os(iOS)
+extension CTCarrier: CarrierInfoProviding {}
+#endif

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CellularServiceInfoProviding.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CellularServiceInfoProviding.swift
@@ -1,0 +1,17 @@
+#if canImport(CoreTelephony)
+import CoreTelephony
+#endif
+
+@available(tvOS, unavailable)
+protocol CellularServiceInfoProviding {
+    var cellularProviders: [CarrierInfoProviding] { get }
+}
+
+#if os(iOS)
+extension CTTelephonyNetworkInfo: CellularServiceInfoProviding {
+
+    var cellularProviders: [CarrierInfoProviding] {
+        serviceSubscriberCellularProviders?.values.compactMap { $0 } ?? []
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
@@ -37,4 +37,21 @@ public struct DeviceInfo: Equatable, Encodable {
     public let osType: String?
     public let osRelease: String?
     public let kernelVersion: String?
+
+    /// The mobile country codes (MCCs) for the user’s cellular service providers.
+    @available(
+        iOS,
+        deprecated: 16.0,
+        message: "The return value is undefined and no guarantee can be made on its stability."
+    )
+    @available(tvOS, unavailable)
+    public let mobileCountryCodes: [String]
+    /// The mobile network codes (MNCs) for the user’s cellular service providers.
+    @available(
+        iOS,
+        deprecated: 16.0,
+        message: "The return value is undefined and no guarantee can be made on its stability."
+    )
+    @available(tvOS, unavailable)
+    public let mobileNetworkCodes: [String]
 }

--- a/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
+++ b/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
@@ -14,7 +14,33 @@ public class DeviceInfoProvider {
     private let appInfoHarvester: AppInfoHarvesting
     private let hardwareInfoHarvester: HardwareInfoHarvesting
     private let osInfoHarvester: OSInfoHarvesting
+    #if os(iOS)
+    private let cellularNetworkInfoHarvester: CellularNetworkInfoHarvesting
 
+    public convenience init() {
+        self.init(
+            identifierHarvester: IdentifierHarvester(),
+            appInfoHarvester: AppInfoHarvester(),
+            hardwareInfoHarvester: HardwareInfoHarvester(),
+            osInfoHarvester: OSInfoHarvester(),
+            cellularNetworkInfoHarvester: CellularNetworkInfoHarvester()
+        )
+    }
+
+    init(
+        identifierHarvester: IdentifierHarvesting,
+        appInfoHarvester: AppInfoHarvesting,
+        hardwareInfoHarvester: HardwareInfoHarvesting,
+        osInfoHarvester: OSInfoHarvesting,
+        cellularNetworkInfoHarvester: CellularNetworkInfoHarvesting
+    ) {
+        self.identifierHarvester = identifierHarvester
+        self.appInfoHarvester = appInfoHarvester
+        self.hardwareInfoHarvester = hardwareInfoHarvester
+        self.osInfoHarvester = osInfoHarvester
+        self.cellularNetworkInfoHarvester = cellularNetworkInfoHarvester
+    }
+    #else
     public convenience init() {
         self.init(
             identifierHarvester: IdentifierHarvester(),
@@ -35,6 +61,7 @@ public class DeviceInfoProvider {
         self.hardwareInfoHarvester = hardwareInfoHarvester
         self.osInfoHarvester = osInfoHarvester
     }
+    #endif
 }
 
 extension DeviceInfoProvider: DeviceInfoProviding {
@@ -49,7 +76,12 @@ extension DeviceInfoProvider: DeviceInfoProviding {
     }
 
     public func getDeviceInfo(_ completion: @escaping (DeviceInfo) -> Void) {
-        let deviceInfo = DeviceInfo(
+        completion(deviceInfo)
+    }
+
+    #if os(iOS)
+    private var deviceInfo: DeviceInfo {
+        .init(
             vendorIdentifier: identifierHarvester.vendorIdentifier,
             localeIdentifier: appInfoHarvester.localeIdentifier,
             userInterfaceStyle: appInfoHarvester.userInterfaceStyle,
@@ -67,9 +99,35 @@ extension DeviceInfoProvider: DeviceInfoProviding {
             osVersion: osInfoHarvester.osVersion,
             osType: osInfoHarvester.osType,
             osRelease: osInfoHarvester.osRelease,
-            kernelVersion: osInfoHarvester.kernelVersion
+            kernelVersion: osInfoHarvester.kernelVersion,
+            mobileCountryCodes: cellularNetworkInfoHarvester.mobileCountryCodes,
+            mobileNetworkCodes: cellularNetworkInfoHarvester.mobileNetworkCodes
         )
-
-        completion(deviceInfo)
     }
+    #else
+    private var deviceInfo: DeviceInfo {
+        .init(
+            vendorIdentifier: identifierHarvester.vendorIdentifier,
+            localeIdentifier: appInfoHarvester.localeIdentifier,
+            userInterfaceStyle: appInfoHarvester.userInterfaceStyle,
+            diskSpace: hardwareInfoHarvester.diskSpaceInfo,
+            screenResolution: hardwareInfoHarvester.displayResolution,
+            screenScale: hardwareInfoHarvester.displayScale,
+            deviceName: hardwareInfoHarvester.deviceName,
+            deviceType: hardwareInfoHarvester.deviceType,
+            deviceModel: hardwareInfoHarvester.deviceModel,
+            memorySize: hardwareInfoHarvester.memorySize,
+            physicalMemory: hardwareInfoHarvester.memorySize,
+            cpuCount: hardwareInfoHarvester.cpuCount,
+            osTimeZoneIdentifier: osInfoHarvester.osTimeZoneIdentifier,
+            osBuild: osInfoHarvester.osBuild,
+            osVersion: osInfoHarvester.osVersion,
+            osType: osInfoHarvester.osType,
+            osRelease: osInfoHarvester.osRelease,
+            kernelVersion: osInfoHarvester.kernelVersion,
+            mobileCountryCodes: [],
+            mobileNetworkCodes: []
+        )
+    }
+    #endif
 }

--- a/Sources/FingerprintJSTests/TestDoubles/Spies/CarrierInfoProvidingSpy.swift
+++ b/Sources/FingerprintJSTests/TestDoubles/Spies/CarrierInfoProvidingSpy.swift
@@ -1,0 +1,26 @@
+@testable import FingerprintJS
+
+@available(tvOS, unavailable)
+final class CarrierInfoProvidingSpy: CarrierInfoProviding {
+
+    var mobileCountryCodeReturnValue: String?
+    var mobileNetworkCodeReturnValue: String?
+
+    private(set) var mobileCountryCodeCallCount: Int = .zero
+    private(set) var mobileNetworkCodeCallCount: Int = .zero
+
+    init(mobileCountryCode: String? = nil, mobileNetworkCode: String? = nil) {
+        self.mobileCountryCodeReturnValue = mobileCountryCode
+        self.mobileNetworkCodeReturnValue = mobileNetworkCode
+    }
+
+    var mobileCountryCode: String? {
+        mobileCountryCodeCallCount += 1
+        return mobileCountryCodeReturnValue
+    }
+
+    var mobileNetworkCode: String? {
+        mobileNetworkCodeCallCount += 1
+        return mobileNetworkCodeReturnValue
+    }
+}

--- a/Sources/FingerprintJSTests/TestDoubles/Spies/CellularServiceInfoProvidingSpy.swift
+++ b/Sources/FingerprintJSTests/TestDoubles/Spies/CellularServiceInfoProvidingSpy.swift
@@ -1,0 +1,14 @@
+@testable import FingerprintJS
+
+@available(tvOS, unavailable)
+final class CellularServiceInfoProvidingSpy: CellularServiceInfoProviding {
+
+    var cellularProvidersReturnValue: [CarrierInfoProviding] = []
+
+    private(set) var cellularProvidersCallCount: Int = .zero
+
+    var cellularProviders: [CarrierInfoProviding] {
+        cellularProvidersCallCount += 1
+        return cellularProvidersReturnValue
+    }
+}

--- a/Sources/FingerprintJSTests/Tests/CellularNetworkInfoHarvesterTests.swift
+++ b/Sources/FingerprintJSTests/Tests/CellularNetworkInfoHarvesterTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+
+@testable import FingerprintJS
+
+#if os(iOS)
+final class CellularNetworkInfoHarvesterTests: XCTestCase {
+    private var cellularServiceInfoProviderSpy: CellularServiceInfoProvidingSpy!
+
+    private var sut: CellularNetworkInfoHarvester!
+
+    override func setUp() {
+        super.setUp()
+        cellularServiceInfoProviderSpy = .init()
+        sut = .init(
+            cellularServiceInfoProvider: cellularServiceInfoProviderSpy
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        cellularServiceInfoProviderSpy = nil
+        super.tearDown()
+    }
+
+    func test_givenNoCelluarProviders_whenMobileCountryCodes_thenReturnsEmptyArray() {
+        // given
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = []
+
+        // when
+        let mobileCountryCodes = sut.mobileCountryCodes
+
+        // then
+        XCTAssertTrue(mobileCountryCodes.isEmpty)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+    }
+
+    func test_givenNoCelluarProviders_whenMobileNetworkCodes_thenReturnsEmptyArray() {
+        // given
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = []
+
+        // when
+        let mobileNetworkCodes = sut.mobileNetworkCodes
+
+        // then
+        XCTAssertTrue(mobileNetworkCodes.isEmpty)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+    }
+
+    func test_givenTwoCelluarProviders_whenMobileCountryCodes_thenReturnsArrayWithTwoElements() {
+        // given
+        let firstProvider = CarrierInfoProvidingSpy(mobileCountryCode: "001")
+        let secondProvider = CarrierInfoProvidingSpy(mobileCountryCode: "048")
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
+            firstProvider,
+            secondProvider,
+        ]
+
+        // when
+        let mobileCountryCodes = sut.mobileCountryCodes
+
+        // then
+        XCTAssertEqual(["001", "048"], mobileCountryCodes)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+        XCTAssertEqual(1, firstProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(0, firstProvider.mobileNetworkCodeCallCount)
+        XCTAssertEqual(1, secondProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(0, secondProvider.mobileNetworkCodeCallCount)
+    }
+
+    func test_givenTwoCelluarProviders_whenMobileNetworkCodes_thenReturnsArrayWithTwoElements() {
+        // given
+        let firstProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "01")
+        let secondProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "06")
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
+            firstProvider,
+            secondProvider,
+        ]
+
+        // when
+        let mobileNetworkCodes = sut.mobileNetworkCodes
+
+        // then
+        XCTAssertEqual(["01", "06"], mobileNetworkCodes)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+        XCTAssertEqual(0, firstProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(1, firstProvider.mobileNetworkCodeCallCount)
+        XCTAssertEqual(0, secondProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(1, secondProvider.mobileNetworkCodeCallCount)
+    }
+
+    func test_givenUnknownCellularProvider_whenMobileCountryCodes_thenReturnsEmptyArray() {
+        // given
+        let unknownProvider = CarrierInfoProvidingSpy()
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
+            unknownProvider
+        ]
+
+        // when
+        let mobileCountryCodes = sut.mobileCountryCodes
+
+        // then
+        XCTAssertTrue(mobileCountryCodes.isEmpty)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+        XCTAssertEqual(1, unknownProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(0, unknownProvider.mobileNetworkCodeCallCount)
+    }
+
+    func test_givenUnknownCellularProvider_whenMobileNetworkCodes_thenReturnsEmptyArray() {
+        // given
+        let unknownProvider = CarrierInfoProvidingSpy()
+        cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
+            unknownProvider
+        ]
+
+        // when
+        let mobileNetworkCodes = sut.mobileNetworkCodes
+
+        // then
+        XCTAssertTrue(mobileNetworkCodes.isEmpty)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
+        XCTAssertEqual(0, unknownProvider.mobileCountryCodeCallCount)
+        XCTAssertEqual(1, unknownProvider.mobileNetworkCodeCallCount)
+    }
+}
+#endif

--- a/Sources/FingerprintJSTests/Tests/CellularNetworkInfoHarvesterTests.swift
+++ b/Sources/FingerprintJSTests/Tests/CellularNetworkInfoHarvesterTests.swift
@@ -46,10 +46,10 @@ final class CellularNetworkInfoHarvesterTests: XCTestCase {
         XCTAssertEqual(1, cellularServiceInfoProviderSpy.cellularProvidersCallCount)
     }
 
-    func test_givenTwoCelluarProviders_whenMobileCountryCodes_thenReturnsArrayWithTwoElements() {
+    func test_givenTwoCelluarProviders_whenMobileCountryCodes_thenReturnsArrayWithTwoElementsInAscendingOrder() {
         // given
-        let firstProvider = CarrierInfoProvidingSpy(mobileCountryCode: "001")
-        let secondProvider = CarrierInfoProvidingSpy(mobileCountryCode: "048")
+        let firstProvider = CarrierInfoProvidingSpy(mobileCountryCode: "048")
+        let secondProvider = CarrierInfoProvidingSpy(mobileCountryCode: "001")
         cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
             firstProvider,
             secondProvider,
@@ -67,10 +67,10 @@ final class CellularNetworkInfoHarvesterTests: XCTestCase {
         XCTAssertEqual(0, secondProvider.mobileNetworkCodeCallCount)
     }
 
-    func test_givenTwoCelluarProviders_whenMobileNetworkCodes_thenReturnsArrayWithTwoElements() {
+    func test_givenTwoCelluarProviders_whenMobileNetworkCodes_thenReturnsArrayWithTwoElementsInAscendingOrder() {
         // given
-        let firstProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "01")
-        let secondProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "06")
+        let firstProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "06")
+        let secondProvider = CarrierInfoProvidingSpy(mobileNetworkCode: "01")
         cellularServiceInfoProviderSpy.cellularProvidersReturnValue = [
             firstProvider,
             secondProvider,


### PR DESCRIPTION
The initial `CellularNetworkInfoHarvester` implementation includes two
properties:
- `mobileCountryCodes` for retrieving the mobile country codes
(MCCs).
- `mobileNetworkCodes` for retrieving the mobile network codes
(MNCs).

Both properties are of `Array<String>` type to correctly handle iPhones
that support Dual SIM mode, as well as iPhones with multiple eSIMs.

The introduced API is available on iOS only, i.e. tvOS is not supported.
Also, in iOS 16 and later, the public API is deprecated, as a result of
Apple deprecating `CTCarrier` API with no replacement. See 
https://developer.apple.com/forums/thread/714876 for details.