### PR TITLE
Add `LocalAuthenticationInfoHarvester` for collecting biometrics-related signals

### DIFF
--- a/FingerprintJS.xcodeproj/project.pbxproj
+++ b/FingerprintJS.xcodeproj/project.pbxproj
@@ -28,6 +28,12 @@
 		159E0BDB294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BDA294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift */; };
 		159E0BDD294108E900E2C38A /* CarrierInfoProvidingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159E0BDC294108E900E2C38A /* CarrierInfoProvidingSpy.swift */; };
 		15D7C62A294A6B010025CE74 /* FingerprintStabilityLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C629294A6B010025CE74 /* FingerprintStabilityLevel.swift */; };
+		15D7C64C298ACE760025CE74 /* AuthenticationContextInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C64B298ACE760025CE74 /* AuthenticationContextInfo.swift */; };
+		15D7C64E298BCAC50025CE74 /* AuthenticationContextInfoProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C64D298BCAC50025CE74 /* AuthenticationContextInfoProviding.swift */; };
+		15D7C650298BD0930025CE74 /* BiometryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C64F298BD0930025CE74 /* BiometryType.swift */; };
+		15D7C654298BD6930025CE74 /* LocalAuthenticationInfoHarvester.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C653298BD6930025CE74 /* LocalAuthenticationInfoHarvester.swift */; };
+		15D7C657298C07220025CE74 /* LocalAuthenticationInfoHarvesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C655298C071A0025CE74 /* LocalAuthenticationInfoHarvesterTests.swift */; };
+		15D7C65A298C0C1D0025CE74 /* AuthenticationContextInfoProvidingDummy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D7C659298C0C1D0025CE74 /* AuthenticationContextInfoProvidingDummy.swift */; };
 		6A0F5C86297898430068BD4D /* SystemControl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A2047F32971ACFA008EC677 /* SystemControl.framework */; };
 		6A1D11412809DBDE00566F75 /* DeviceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D11402809DBDE00566F75 /* DeviceInfo.swift */; };
 		6A1D1143280F1B6600566F75 /* DeviceInfoProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1D1142280F1B6600566F75 /* DeviceInfoProvider.swift */; };
@@ -46,9 +52,9 @@
 		6A3BB827280588FD00D2EBB9 /* OSInfoHarvesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3BB826280588FD00D2EBB9 /* OSInfoHarvesterTests.swift */; };
 		6A3BB82928058B4900D2EBB9 /* IdentifierHarvesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A3BB82828058B4900D2EBB9 /* IdentifierHarvesterTests.swift */; };
 		6A44A31928CF8FAF0026DCD8 /* SHA256HashingFunctionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A44A31828CF8FAF0026DCD8 /* SHA256HashingFunctionTests.swift */; };
-		6A69CA8029789C0C005AF63F /* SubsystemValueRetrievalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A69CA7F29789C09005AF63F /* SubsystemValueRetrievalIntegrationTests.swift */; };
 		6A53B7332976ECD400DD6872 /* FingerprintJSVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A53B7322976ECD400DD6872 /* FingerprintJSVersion.swift */; };
 		6A53B737297716FF00DD6872 /* FingerprintJSVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A53B735297716EC00DD6872 /* FingerprintJSVersionTests.swift */; };
+		6A69CA8029789C0C005AF63F /* SubsystemValueRetrievalIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A69CA7F29789C09005AF63F /* SubsystemValueRetrievalIntegrationTests.swift */; };
 		6A7D016527FB31A30037E190 /* DiskSpaceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7D016427FB31A30037E190 /* DiskSpaceInfo.swift */; };
 		6A82A18327D65DB4007C023F /* FingerprintJS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6A82A17A27D65DB4007C023F /* FingerprintJS.framework */; };
 		6A82A19727D74D5B007C023F /* Fingerprintable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A82A19627D74D5B007C023F /* Fingerprintable.swift */; };
@@ -123,6 +129,12 @@
 		159E0BDA294107AE00E2C38A /* CellularServiceInfoProvidingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellularServiceInfoProvidingSpy.swift; sourceTree = "<group>"; };
 		159E0BDC294108E900E2C38A /* CarrierInfoProvidingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarrierInfoProvidingSpy.swift; sourceTree = "<group>"; };
 		15D7C629294A6B010025CE74 /* FingerprintStabilityLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintStabilityLevel.swift; sourceTree = "<group>"; };
+		15D7C64B298ACE760025CE74 /* AuthenticationContextInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationContextInfo.swift; sourceTree = "<group>"; };
+		15D7C64D298BCAC50025CE74 /* AuthenticationContextInfoProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationContextInfoProviding.swift; sourceTree = "<group>"; };
+		15D7C64F298BD0930025CE74 /* BiometryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometryType.swift; sourceTree = "<group>"; };
+		15D7C653298BD6930025CE74 /* LocalAuthenticationInfoHarvester.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthenticationInfoHarvester.swift; sourceTree = "<group>"; };
+		15D7C655298C071A0025CE74 /* LocalAuthenticationInfoHarvesterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthenticationInfoHarvesterTests.swift; sourceTree = "<group>"; };
+		15D7C659298C0C1D0025CE74 /* AuthenticationContextInfoProvidingDummy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationContextInfoProvidingDummy.swift; sourceTree = "<group>"; };
 		6A0F5C82297898430068BD4D /* SystemControlTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SystemControlTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A0F5C8E297898B50068BD4D /* FingerprintJS.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = FingerprintJS.xctestplan; path = Tests/FingerprintJS.xctestplan; sourceTree = "<group>"; };
 		6A1D11402809DBDE00566F75 /* DeviceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceInfo.swift; sourceTree = "<group>"; };
@@ -141,9 +153,9 @@
 		6A47E06E296CA9EC00717C22 /* RawPointerConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RawPointerConvertible.swift; sourceTree = "<group>"; };
 		6A47E070296CA9FA00717C22 /* SystemControlValueDefinition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemControlValueDefinition.swift; sourceTree = "<group>"; };
 		6A47E071296CA9FA00717C22 /* SystemControlValuesProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemControlValuesProvider.swift; sourceTree = "<group>"; };
-		6A69CA7F29789C09005AF63F /* SubsystemValueRetrievalIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubsystemValueRetrievalIntegrationTests.swift; sourceTree = "<group>"; };
 		6A53B7322976ECD400DD6872 /* FingerprintJSVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintJSVersion.swift; sourceTree = "<group>"; };
 		6A53B735297716EC00DD6872 /* FingerprintJSVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FingerprintJSVersionTests.swift; sourceTree = "<group>"; };
+		6A69CA7F29789C09005AF63F /* SubsystemValueRetrievalIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubsystemValueRetrievalIntegrationTests.swift; sourceTree = "<group>"; };
 		6A7D016427FB31A30037E190 /* DiskSpaceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskSpaceInfo.swift; sourceTree = "<group>"; };
 		6A82A17A27D65DB4007C023F /* FingerprintJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FingerprintJS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6A82A18227D65DB4007C023F /* FingerprintJSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FingerprintJSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -230,8 +242,9 @@
 		159E0BB3292D194400E2C38A /* TestDoubles */ = {
 			isa = PBXGroup;
 			children = (
-				159E0BB4292D196400E2C38A /* Spies */,
+				15D7C658298C0BEA0025CE74 /* Dummies */,
 				6AB7146227EB636E004BBCF3 /* Mocks */,
+				159E0BB4292D196400E2C38A /* Spies */,
 			);
 			path = TestDoubles;
 			sourceTree = "<group>";
@@ -306,6 +319,31 @@
 			path = Providers;
 			sourceTree = "<group>";
 		};
+		15D7C651298BD6680025CE74 /* LocalAuthenticationInfoHarvester */ = {
+			isa = PBXGroup;
+			children = (
+				15D7C652298BD6810025CE74 /* Providers */,
+				15D7C653298BD6930025CE74 /* LocalAuthenticationInfoHarvester.swift */,
+			);
+			path = LocalAuthenticationInfoHarvester;
+			sourceTree = "<group>";
+		};
+		15D7C652298BD6810025CE74 /* Providers */ = {
+			isa = PBXGroup;
+			children = (
+				15D7C64D298BCAC50025CE74 /* AuthenticationContextInfoProviding.swift */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		15D7C658298C0BEA0025CE74 /* Dummies */ = {
+			isa = PBXGroup;
+			children = (
+				15D7C659298C0C1D0025CE74 /* AuthenticationContextInfoProvidingDummy.swift */,
+			);
+			path = Dummies;
+			sourceTree = "<group>";
+		};
 		6A2E484B2963352000753ACD /* IdentifierHarvester */ = {
 			isa = PBXGroup;
 			children = (
@@ -321,6 +359,19 @@
 				6A2E484D2963355B00753ACD /* VendorIdentifierProviding.swift */,
 			);
 			path = Providers;
+			sourceTree = "<group>";
+		};
+		6A53B7342977168200DD6872 /* Harvesters */ = {
+			isa = PBXGroup;
+			children = (
+				159E0BAD292D149700E2C38A /* AppInfoHarvesterTests.swift */,
+				159E0BD82940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift */,
+				6AC362AA280013E200C4768A /* HardwareInfoHarvesterTests.swift */,
+				6A3BB82828058B4900D2EBB9 /* IdentifierHarvesterTests.swift */,
+				15D7C655298C071A0025CE74 /* LocalAuthenticationInfoHarvesterTests.swift */,
+				6A3BB826280588FD00D2EBB9 /* OSInfoHarvesterTests.swift */,
+			);
+			path = Harvesters;
 			sourceTree = "<group>";
 		};
 		6A69CA7D29789C09005AF63F /* SystemControlTests */ = {
@@ -340,23 +391,13 @@
 			path = Integration;
 			sourceTree = "<group>";
 		};
-		6A53B7342977168200DD6872 /* Harvesters */ = {
-			isa = PBXGroup;
-			children = (
-				159E0BAD292D149700E2C38A /* AppInfoHarvesterTests.swift */,
-				6AC362AA280013E200C4768A /* HardwareInfoHarvesterTests.swift */,
-				6A3BB82828058B4900D2EBB9 /* IdentifierHarvesterTests.swift */,
-				6A3BB826280588FD00D2EBB9 /* OSInfoHarvesterTests.swift */,
-				159E0BD82940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift */,
-			);
-			path = Harvesters;
-			sourceTree = "<group>";
-		};
 		6A7D016327FB31940037E190 /* DataExchange */ = {
 			isa = PBXGroup;
 			children = (
-				6A7D016427FB31A30037E190 /* DiskSpaceInfo.swift */,
+				15D7C64B298ACE760025CE74 /* AuthenticationContextInfo.swift */,
+				15D7C64F298BD0930025CE74 /* BiometryType.swift */,
 				6A1D11402809DBDE00566F75 /* DeviceInfo.swift */,
+				6A7D016427FB31A30037E190 /* DiskSpaceInfo.swift */,
 				159E0BAB292CE35700E2C38A /* UserInterfaceStyle.swift */,
 			);
 			path = DataExchange;
@@ -367,9 +408,9 @@
 			children = (
 				6A0F5C8E297898B50068BD4D /* FingerprintJS.xctestplan */,
 				6A82A17C27D65DB4007C023F /* FingerprintJS */,
+				6A82A18627D65DB4007C023F /* FingerprintJSTests */,
 				6A82A19C27D775A2007C023F /* SystemControl */,
 				6A69CA7D29789C09005AF63F /* SystemControlTests */,
-				6A82A18627D65DB4007C023F /* FingerprintJSTests */,
 				6A82A17B27D65DB4007C023F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -437,11 +478,12 @@
 		6A82A19827D76BFE007C023F /* Harvesters */ = {
 			isa = PBXGroup;
 			children = (
-				6A2E484B2963352000753ACD /* IdentifierHarvester */,
-				159E0BD02940D2FD00E2C38A /* CellularNetworkInfoHarvester */,
-				159E0BBC293A5DB100E2C38A /* OSInfoHarvester */,
-				159E0BC6293F795E00E2C38A /* HardwareInfoHarvester */,
 				159E0BAF292D17E500E2C38A /* AppInfoHarvester */,
+				159E0BD02940D2FD00E2C38A /* CellularNetworkInfoHarvester */,
+				159E0BC6293F795E00E2C38A /* HardwareInfoHarvester */,
+				6A2E484B2963352000753ACD /* IdentifierHarvester */,
+				15D7C651298BD6680025CE74 /* LocalAuthenticationInfoHarvester */,
+				159E0BBC293A5DB100E2C38A /* OSInfoHarvester */,
 				6A7D016327FB31940037E190 /* DataExchange */,
 			);
 			path = Harvesters;
@@ -739,12 +781,15 @@
 				159E0BC3293E4B7A00E2C38A /* LocaleInfoProviding.swift in Sources */,
 				6AC03F4B27DE574100EF9DB7 /* DeviceInfoItem.swift in Sources */,
 				6A9B7CB227E7AA8E002B9939 /* DeviceInfoTreeProvider.swift in Sources */,
+				15D7C64E298BCAC50025CE74 /* AuthenticationContextInfoProviding.swift in Sources */,
 				6A1D1143280F1B6600566F75 /* DeviceInfoProvider.swift in Sources */,
 				6A9B7CBA27E7B3D4002B9939 /* FingerprintTreeCalculator.swift in Sources */,
 				159E0BD72940D66600E2C38A /* CellularServiceInfoProviding.swift in Sources */,
+				15D7C64C298ACE760025CE74 /* AuthenticationContextInfo.swift in Sources */,
 				6A9B7CB627E7AC55002B9939 /* CGSize+CustomStringConvertible.swift in Sources */,
 				6A9B7CB027E36F66002B9939 /* CompoundTreeBuilder.swift in Sources */,
 				6A2E484E2963355B00753ACD /* VendorIdentifierProviding.swift in Sources */,
+				15D7C654298BD6930025CE74 /* LocalAuthenticationInfoHarvester.swift in Sources */,
 				159E0BAA292CD1C600E2C38A /* AppInfoHarvester.swift in Sources */,
 				6A9B7CB427E7AB6D002B9939 /* FingerprintFunction.swift in Sources */,
 				159E0BB2292D18B800E2C38A /* UserInterfaceTraitsProviding.swift in Sources */,
@@ -764,6 +809,7 @@
 				6A82A1AF27DA0A19007C023F /* Digest+StringOutput.swift in Sources */,
 				6A9B7CAE27E220F1002B9939 /* Fingerprinter.swift in Sources */,
 				6A82A19B27D76CD6007C023F /* HardwareInfoHarvester.swift in Sources */,
+				15D7C650298BD0930025CE74 /* BiometryType.swift in Sources */,
 				159E0BCB293F7A3F00E2C38A /* DeviceIdentificationInfoProviding.swift in Sources */,
 				159E0BD52940D41600E2C38A /* CarrierInfoProviding.swift in Sources */,
 				6A82A1A427D897F2007C023F /* KeychainIdentifierStorage.swift in Sources */,
@@ -780,6 +826,7 @@
 			files = (
 				6A3BB827280588FD00D2EBB9 /* OSInfoHarvesterTests.swift in Sources */,
 				6A3BB82928058B4900D2EBB9 /* IdentifierHarvesterTests.swift in Sources */,
+				15D7C65A298C0C1D0025CE74 /* AuthenticationContextInfoProvidingDummy.swift in Sources */,
 				6A53B737297716FF00DD6872 /* FingerprintJSVersionTests.swift in Sources */,
 				6AB7146427EB65B1004BBCF3 /* MockHashingFunction.swift in Sources */,
 				159E0BD92940DBCB00E2C38A /* CellularNetworkInfoHarvesterTests.swift in Sources */,
@@ -794,6 +841,7 @@
 				6A23866328042DFB002D09F3 /* DocumentsDirectoryAttributesProvidingMock.swift in Sources */,
 				159E0BC5293E4FF900E2C38A /* LocaleInfoProvidingSpy.swift in Sources */,
 				6AB7146127EB612D004BBCF3 /* FingerprintTreeCalculatorTests.swift in Sources */,
+				15D7C657298C07220025CE74 /* LocalAuthenticationInfoHarvesterTests.swift in Sources */,
 				6A44A31928CF8FAF0026DCD8 /* SHA256HashingFunctionTests.swift in Sources */,
 				6AC362B628042C1500C4768A /* CPUInfoProvidingMock.swift in Sources */,
 				159E0BB6292D19B700E2C38A /* UserInterfaceTraitsProvidingSpy.swift in Sources */,

--- a/Sources/FingerprintJS/Fingerprints/CompoundTreeBuilder.swift
+++ b/Sources/FingerprintJS/Fingerprints/CompoundTreeBuilder.swift
@@ -10,6 +10,7 @@ struct CompoundTreeBuilder {
         ]
         #if os(iOS)
         providers.append(CellularNetworkInfoHarvester())
+        providers.append(LocalAuthenticationInfoHarvester())
         #endif
         self.init(providers: providers)
     }

--- a/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
+++ b/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
@@ -277,4 +277,43 @@ extension CellularNetworkInfoHarvester: DeviceInfoTreeProvider {
         ]
     }
 }
+
+extension LocalAuthenticationInfoHarvester: DeviceInfoTreeProvider {
+    func buildTree(_ configuration: Configuration) -> DeviceInfoItem {
+        .init(
+            label: "Local Authentication",
+            value: .category,
+            children: itemsMatching(configuration: configuration)
+        )
+    }
+
+    var annotatedItems: [AnnotatedInfoItem] {
+        [
+            AnnotatedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Passcode",
+                    value: .info(isPasscodeEnabled ? "Enabled" : "Disabled")
+                ),
+                stabilityLevel: .optimal,
+                versions: .since(.v5)
+            ),
+            AnnotatedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Biometrics",
+                    value: .info(isBiometricsEnabled ? "Enabled" : "Disabled")
+                ),
+                stabilityLevel: .optimal,
+                versions: .since(.v5)
+            ),
+            AnnotatedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Biometry type",
+                    value: .info(biometryType.description)
+                ),
+                stabilityLevel: .stable,
+                versions: .since(.v5)
+            ),
+        ]
+    }
+}
 #endif

--- a/Sources/FingerprintJS/Harvesters/DataExchange/AuthenticationContextInfo.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/AuthenticationContextInfo.swift
@@ -1,0 +1,10 @@
+/// A collection of information about the local authentication settings.
+@available(tvOS, unavailable)
+public struct LocalAuthenticationInfo: Equatable, Encodable {
+    /// A Boolean value indicating whether the device passcode is enabled.
+    public let isPasscodeEnabled: Bool
+    /// A Boolean value indicating whether the on-device biometric authentication is enabled.
+    public let isBiometricsEnabled: Bool
+    /// The type of biometric authentication supported by the device.
+    public let biometryType: BiometryType
+}

--- a/Sources/FingerprintJS/Harvesters/DataExchange/BiometryType.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/BiometryType.swift
@@ -1,0 +1,49 @@
+#if canImport(LocalAuthentication)
+import LocalAuthentication
+#endif
+
+/// Constants that indicate the type of biometric authentication supported by the device.
+@available(tvOS, unavailable)
+public enum BiometryType: String, Encodable {
+    /// The device supports Face ID.
+    case faceID
+    /// The device supports Touch ID.
+    case touchID
+    /// Biometric authentication is not supported.
+    case none
+    /// The device supports some unknown type of biometric authentication.
+    case unknown
+}
+
+#if os(iOS)
+extension BiometryType: CustomStringConvertible {
+
+    /// A textual representation of this value.
+    public var description: String {
+        switch self {
+        case .faceID:
+            return "Face ID"
+        case .touchID:
+            return "Touch ID"
+        case .none, .unknown:
+            return "<\(rawValue)>"
+        }
+    }
+}
+
+extension BiometryType {
+
+    init(_ biometryType: LABiometryType) {
+        switch biometryType {
+        case .faceID:
+            self = .faceID
+        case .touchID:
+            self = .touchID
+        case .none:
+            self = .none
+        @unknown default:
+            self = .unknown
+        }
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
@@ -3,7 +3,7 @@ import Foundation
 public struct DeviceInfo: Equatable, Encodable {
     public let vendorIdentifier: UUID?
 
-    /// The identifier for the locale representing the user's region settings.
+    /// The identifier for the locale representing the user's language and region settings.
     public let localeIdentifier: String
     /// The style associated with the user interface of the app.
     public let userInterfaceStyle: UserInterfaceStyle
@@ -60,4 +60,8 @@ public struct DeviceInfo: Equatable, Encodable {
     )
     @available(tvOS, unavailable)
     public let mobileNetworkCodes: [String]
+
+    /// The information about the local authentication settings.
+    @available(tvOS, unavailable)
+    public let localAuthentication: LocalAuthenticationInfo
 }

--- a/Sources/FingerprintJS/Harvesters/DataExchange/UserInterfaceStyle.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/UserInterfaceStyle.swift
@@ -4,10 +4,8 @@ import UIKit
 public enum UserInterfaceStyle: String, Encodable {
     /// The dark interface style.
     case dark
-
     /// The light interface style.
     case light
-
     /// An undefined user interface style.
     case undefined
 }

--- a/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/LocalAuthenticationInfoHarvester.swift
+++ b/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/LocalAuthenticationInfoHarvester.swift
@@ -1,0 +1,44 @@
+#if canImport(LocalAuthentication)
+import LocalAuthentication
+#endif
+
+@available(tvOS, unavailable)
+protocol LocalAuthenticationInfoHarvesting {
+    var isPasscodeEnabled: Bool { get }
+    var isBiometricsEnabled: Bool { get }
+    var biometryType: BiometryType { get }
+}
+
+@available(tvOS, unavailable)
+struct LocalAuthenticationInfoHarvester {
+
+    private let authenticationContextInfoProvider: AuthenticationContextInfoProviding
+
+    init(authenticationContextInfoProvider: AuthenticationContextInfoProviding) {
+        self.authenticationContextInfoProvider = authenticationContextInfoProvider
+    }
+}
+
+#if os(iOS)
+extension LocalAuthenticationInfoHarvester {
+
+    init() {
+        self.init(authenticationContextInfoProvider: LAContext())
+    }
+}
+
+extension LocalAuthenticationInfoHarvester: LocalAuthenticationInfoHarvesting {
+
+    var isPasscodeEnabled: Bool {
+        authenticationContextInfoProvider.isPasscodeEnabled
+    }
+
+    var isBiometricsEnabled: Bool {
+        authenticationContextInfoProvider.isBiometricsEnabled
+    }
+
+    var biometryType: BiometryType {
+        authenticationContextInfoProvider.supportedBiometryType
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/Providers/AuthenticationContextInfoProviding.swift
+++ b/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/Providers/AuthenticationContextInfoProviding.swift
@@ -22,6 +22,11 @@ extension LAContext: AuthenticationContextInfoProviding {
 
     var supportedBiometryType: BiometryType {
         if biometryType == .none {
+            // As the LAContext documentation states, the biometryType property is
+            // set only after the canEvaluatePolicy(_:error:) method is called,
+            // and is set no matter what the call returns. The default value of this
+            // property is LABiometryType.none, so with the below method call we make
+            // sure that the property has the correct value.
             _ = canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
         }
 

--- a/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/Providers/AuthenticationContextInfoProviding.swift
+++ b/Sources/FingerprintJS/Harvesters/LocalAuthenticationInfoHarvester/Providers/AuthenticationContextInfoProviding.swift
@@ -1,0 +1,31 @@
+#if canImport(LocalAuthentication)
+import LocalAuthentication
+#endif
+
+@available(tvOS, unavailable)
+protocol AuthenticationContextInfoProviding {
+    var isPasscodeEnabled: Bool { get }
+    var isBiometricsEnabled: Bool { get }
+    var supportedBiometryType: BiometryType { get }
+}
+
+#if os(iOS)
+extension LAContext: AuthenticationContextInfoProviding {
+
+    var isPasscodeEnabled: Bool {
+        canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
+    }
+
+    var isBiometricsEnabled: Bool {
+        canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+    }
+
+    var supportedBiometryType: BiometryType {
+        if biometryType == .none {
+            _ = canEvaluatePolicy(.deviceOwnerAuthentication, error: nil)
+        }
+
+        return .init(biometryType)
+    }
+}
+#endif

--- a/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
+++ b/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
@@ -16,6 +16,7 @@ public class DeviceInfoProvider {
     private let osInfoHarvester: OSInfoHarvesting
     #if os(iOS)
     private let cellularNetworkInfoHarvester: CellularNetworkInfoHarvesting
+    private let localAuthenticationInfoHarvester: LocalAuthenticationInfoHarvesting
 
     public convenience init() {
         self.init(
@@ -23,7 +24,8 @@ public class DeviceInfoProvider {
             appInfoHarvester: AppInfoHarvester(),
             hardwareInfoHarvester: HardwareInfoHarvester(),
             osInfoHarvester: OSInfoHarvester(),
-            cellularNetworkInfoHarvester: CellularNetworkInfoHarvester()
+            cellularNetworkInfoHarvester: CellularNetworkInfoHarvester(),
+            localAuthenticationInfoHarvester: LocalAuthenticationInfoHarvester()
         )
     }
 
@@ -32,13 +34,15 @@ public class DeviceInfoProvider {
         appInfoHarvester: AppInfoHarvesting,
         hardwareInfoHarvester: HardwareInfoHarvesting,
         osInfoHarvester: OSInfoHarvesting,
-        cellularNetworkInfoHarvester: CellularNetworkInfoHarvesting
+        cellularNetworkInfoHarvester: CellularNetworkInfoHarvesting,
+        localAuthenticationInfoHarvester: LocalAuthenticationInfoHarvesting
     ) {
         self.identifierHarvester = identifierHarvester
         self.appInfoHarvester = appInfoHarvester
         self.hardwareInfoHarvester = hardwareInfoHarvester
         self.osInfoHarvester = osInfoHarvester
         self.cellularNetworkInfoHarvester = cellularNetworkInfoHarvester
+        self.localAuthenticationInfoHarvester = localAuthenticationInfoHarvester
     }
     #else
     public convenience init() {
@@ -103,7 +107,12 @@ extension DeviceInfoProvider: DeviceInfoProviding {
             kernelVersion: osInfoHarvester.kernelVersion,
             bootTime: osInfoHarvester.bootTime,
             mobileCountryCodes: cellularNetworkInfoHarvester.mobileCountryCodes,
-            mobileNetworkCodes: cellularNetworkInfoHarvester.mobileNetworkCodes
+            mobileNetworkCodes: cellularNetworkInfoHarvester.mobileNetworkCodes,
+            localAuthentication: .init(
+                isPasscodeEnabled: localAuthenticationInfoHarvester.isPasscodeEnabled,
+                isBiometricsEnabled: localAuthenticationInfoHarvester.isBiometricsEnabled,
+                biometryType: localAuthenticationInfoHarvester.biometryType
+            )
         )
     }
     #else
@@ -130,7 +139,12 @@ extension DeviceInfoProvider: DeviceInfoProviding {
             kernelVersion: osInfoHarvester.kernelVersion,
             bootTime: osInfoHarvester.bootTime,
             mobileCountryCodes: [],
-            mobileNetworkCodes: []
+            mobileNetworkCodes: [],
+            localAuthentication: .init(
+                isPasscodeEnabled: false,
+                isBiometricsEnabled: false,
+                biometryType: .none
+            )
         )
     }
     #endif

--- a/Sources/FingerprintJS/Library/FingerprintJSVersion.swift
+++ b/Sources/FingerprintJS/Library/FingerprintJSVersion.swift
@@ -8,11 +8,13 @@ public enum FingerprintJSVersion {
     case v3
     /// Version 4.
     case v4
+    /// Version 5.
+    case v5
 }
 
 extension FingerprintJSVersion {
     /// Latest fingerprint version.
-    public static var latest: Self { .v4 }
+    public static var latest: Self { .v5 }
 }
 
 extension FingerprintJSVersion: CaseIterable, Equatable {}

--- a/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
+++ b/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
@@ -22,7 +22,7 @@ final class FingerprintJSVersionTests: XCTestCase {
         let versions = [FingerprintJSVersion].since(fromVersion)
 
         // then
-        XCTAssertEqual(versions, [.v2, .v3, .v4])
+        XCTAssertEqual(versions, [.v2, .v3, .v4, .v5])
     }
 
     func test_whenAll_thenReturnsAllVersions() {
@@ -30,7 +30,7 @@ final class FingerprintJSVersionTests: XCTestCase {
         let versions = [FingerprintJSVersion].all
 
         // then
-        XCTAssertEqual(versions, [.v1, .v2, .v3, .v4])
+        XCTAssertEqual(versions, [.v1, .v2, .v3, .v4, .v5])
     }
 
     func test_whenLatest_thenReturnsVersionFour() {
@@ -38,6 +38,6 @@ final class FingerprintJSVersionTests: XCTestCase {
         let latest = FingerprintJSVersion.latest
 
         // then
-        XCTAssertEqual(latest, .v4)
+        XCTAssertEqual(latest, .v5)
     }
 }

--- a/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
+++ b/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
@@ -33,7 +33,7 @@ final class FingerprintJSVersionTests: XCTestCase {
         XCTAssertEqual(versions, [.v1, .v2, .v3, .v4, .v5])
     }
 
-    func test_whenLatest_thenReturnsVersionFour() {
+    func test_whenLatest_thenReturnsVersionFive() {
         // when
         let latest = FingerprintJSVersion.latest
 

--- a/Tests/FingerprintJSTests/Harvesters/AppInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/AppInfoHarvesterTests.swift
@@ -170,4 +170,44 @@ final class AppInfoHarvesterTests: XCTestCase {
         let itemLabels = itemsTree.children?.map(\.label) ?? []
         XCTAssertTrue(itemLabels.isEmpty)
     }
+
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Locale identifier",
+            "User interface style",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
 }

--- a/Tests/FingerprintJSTests/Harvesters/CellularNetworkInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/CellularNetworkInfoHarvesterTests.swift
@@ -201,5 +201,45 @@ final class CellularNetworkInfoHarvesterTests: XCTestCase {
         let itemLabels = itemsTree.children?.map(\.label) ?? []
         XCTAssertTrue(itemLabels.isEmpty)
     }
+
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Mobile country codes",
+            "Mobile network codes",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
 }
 #endif

--- a/Tests/FingerprintJSTests/Harvesters/HardwareInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/HardwareInfoHarvesterTests.swift
@@ -422,4 +422,70 @@ final class HardwareInfoHarvesterTests: XCTestCase {
         ]
         XCTAssertEqual(expectedItemLabels, itemLabels)
     }
+
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Device name",
+            "Device type",
+            "Device model",
+            "Display resolution",
+            "Display scale",
+            "Physical memory",
+            "Processor count",
+            "Free disk space (B)",
+            "Total disk space (B)",
+            "Device hostname",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Device type",
+            "Device model",
+            "Display resolution",
+            "Display scale",
+            "Physical memory",
+            "Processor count",
+            "Total disk space (B)",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Device type",
+            "Device model",
+            "Display resolution",
+            "Display scale",
+            "Physical memory",
+            "Processor count",
+            "Total disk space (B)",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
 }

--- a/Tests/FingerprintJSTests/Harvesters/IdentifierHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/IdentifierHarvesterTests.swift
@@ -198,6 +198,48 @@ final class IdentifierHarvesterTests: XCTestCase {
         XCTAssertTrue(itemLabels.isEmpty)
     }
 
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Vendor identifier"
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Vendor identifier"
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
     func
         test_givenIdentifierMissingLegacyIdentifierPresent_whenVendorIdentifier_thenMigratesLegacyIdentifierToNewStorage()
     {

--- a/Tests/FingerprintJSTests/Harvesters/LocalAuthenticationInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/LocalAuthenticationInfoHarvesterTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+
+@testable import FingerprintJS
+
+#if os(iOS)
+final class LocalAuthenticationInfoHarvesterTests: XCTestCase {
+
+    private var sut: LocalAuthenticationInfoHarvester!
+
+    override func setUp() {
+        super.setUp()
+        sut = .init(
+            authenticationContextInfoProvider: AuthenticationContextInfoProvidingDummy()
+        )
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Passcode",
+            "Biometrics",
+            "Biometry type",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Passcode",
+            "Biometrics",
+            "Biometry type",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Biometry type"
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+}
+#endif

--- a/Tests/FingerprintJSTests/Harvesters/OSInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/OSInfoHarvesterTests.swift
@@ -247,4 +247,56 @@ final class OSInfoHarvesterTests: XCTestCase {
         let itemLabels = itemsTree.children?.map(\.label) ?? []
         XCTAssertTrue(itemLabels.isEmpty)
     }
+
+    func test_givenConfigurationWithVersionFiveAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "OS time zone identifier",
+            "OS release",
+            "OS type",
+            "OS version",
+            "Kernel version",
+            "Boot time",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndOptimalStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "OS time zone identifier",
+            "OS release",
+            "OS type",
+            "OS version",
+            "Kernel version",
+            "Boot time",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
 }

--- a/Tests/FingerprintJSTests/TestDoubles/Dummies/AuthenticationContextInfoProvidingDummy.swift
+++ b/Tests/FingerprintJSTests/TestDoubles/Dummies/AuthenticationContextInfoProvidingDummy.swift
@@ -1,0 +1,8 @@
+@testable import FingerprintJS
+
+@available(tvOS, unavailable)
+struct AuthenticationContextInfoProvidingDummy: AuthenticationContextInfoProviding {
+    let isPasscodeEnabled: Bool = false
+    let isBiometricsEnabled: Bool = false
+    let supportedBiometryType: BiometryType = .unknown
+}


### PR DESCRIPTION
The initial `LocalAuthenticationInfoHarvester` implementation includes
three properties:
- `isPasscodeEnabled` indicating whether the device passcode is
enabled.
- `isBiometricsEnabled` indicating whether the on-device biometric
authentication is enabled.
- `biometryType` for retrieving the type of biometric authentication
supported by the device.

The introduced API is available on iOS only, i.e. tvOS is not supported.

Fingerprint version `v5` was introduced to accommodate the new
signals. 