### PR TITLE
Bump Swift tools version to 5.7

### DIFF
--- a/FingerprintJS.podspec
+++ b/FingerprintJS.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |spec|
   # Build (deployment target, Swift versions)
   spec.ios.deployment_target = '12.0'
   spec.tvos.deployment_target = '12.0'
-  spec.swift_versions = ['5.5', '5.6', '5.7']
+  spec.swift_versions = ['5.7', '5.8']
   spec.default_subspec = 'Core'
 
   # Core

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,13 @@
-// swift-tools-version:5.5
+// swift-tools-version: 5.7
 
 import PackageDescription
 
 let package = Package(
     name: "FingerprintJS",
-    platforms: [.iOS(.v12), .tvOS(.v12)],
+    platforms: [
+        .iOS(.v12),
+        .tvOS(.v12),
+    ],
     products: [
         .library(
             name: "FingerprintJS",
@@ -16,14 +19,14 @@ let package = Package(
         ),
     ],
     targets: [
+        // Client Libraries
         .target(
             name: "FingerprintJS",
             dependencies: ["SystemControl"]
         ),
-        .target(
-            name: "SystemControl",
-            dependencies: []
-        ),
+        .target(name: "SystemControl"),
+
+        // Tests
         .testTarget(
             name: "FingerprintJSTests",
             dependencies: ["FingerprintJS"]

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@
 <p align="center">Lightweight iOS library for local device fingerprinting</p>
 
 <p align="center">
-    <a href="https://cocoapods.org/pods/FingerprintJS">
-        <img src="https://img.shields.io/cocoapods/p/ios" alt="Supported platforms">
-    </a>
-    <a href="https://cocoapods.org/pods/FingerprintJS">
-        <img src="https://img.shields.io/cocoapods/v/FingerprintJS" alt="Pod version">
-    </a>
+  <a href="https://www.swift.org/download/">
+    <img src="https://img.shields.io/badge/Swift-5.8%20%7C%205.7-red" alt="Supported Swift versions">
+  </a>
+  <a href="https://fingerprint.com/sdk-libraries/">
+    <img src="https://img.shields.io/badge/Platforms-iOS%20%7C%20tvOS-red" alt="Supported platforms">
+  </a>
+  <a href="https://cocoapods.org/pods/FingerprintJS/">
+    <img src="https://img.shields.io/cocoapods/v/FingerprintJS.svg?style=flat" alt="Pod version">
+  </a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
> **Note**
> Following the recent App Store submission requirements update, all iOS,
> iPadOS, and watchOS apps submitted to the App Store must be built
> with Xcode 14.1 (Swift 5.7) or later.