### PR TITLE
Fix Core Telephony API use causing OS-level error msgs on iOS Simulator

### DIFF
--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
@@ -21,9 +21,19 @@ struct CellularNetworkInfoHarvester {
 #if os(iOS)
 extension CellularNetworkInfoHarvester {
 
+    #if !targetEnvironment(simulator)
     init() {
         self.init(cellularServiceInfoProvider: CTTelephonyNetworkInfo())
     }
+    #else
+    private struct CellularServiceInfoProviderFake: CellularServiceInfoProviding {
+        var cellularProviders: [CarrierInfoProviding] { [] }
+    }
+
+    init() {
+        self.init(cellularServiceInfoProvider: CellularServiceInfoProviderFake())
+    }
+    #endif
 }
 
 extension CellularNetworkInfoHarvester: CellularNetworkInfoHarvesting {


### PR DESCRIPTION
On iOS Simulator, the `com.apple.commcenter.coretelephony` XPC Service
appears to be unavailable and an attempt to communicate with it
produces the following error messages originating from
`com.apple.CoreTelephony` subsystem.

```
The connection to service named com.apple.commcenter.coretelephony.xpc
was invalidated: failed at lookup with error 3 - No such process.
```

These error messages pollute the app logs that get printed to the
debug console, which makes the debugging inconvenient.

To resolve the above inconvenience, the code that uses
`CTTelephonyNetworkInfo` API is now conditionally compiled, such that
the API is only called when targeting a physical iDevice.