### PR TITLE
fix: Use `Task` instead of `async`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Note: If you've never used CocoaPods for dependency management, check out their 
 import FingerprintJS
  
 let fingerprinter = FingerprinterFactory.getInstance()
-async {
+Task {
     // Get fingerprint for the current device
-    let fingerprint = await fingerprinter.getFingerprint()
-    
-    // Do something awesome with the fingerprint
+    if let fingerprint = await fingerprinter.getFingerprint() {
+      // Do something awesome with the fingerprint  
+    }
 }
 ```
 


### PR DESCRIPTION
Updated Readme to use Task wrapper, as `async {}` will be removed very soon from Swift specs