### PR TITLE
Add `mobileNetworkTechnologies` signal to `CellularNetworkInfoHarvester`

### DIFF
--- a/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
+++ b/Sources/FingerprintJS/Fingerprints/DeviceInfoTreeProvider.swift
@@ -258,6 +258,14 @@ extension CellularNetworkInfoHarvester: DeviceInfoTreeProvider {
                 stabilityLevel: .unique,
                 versions: .since(.v3)
             ),
+            AnnotatedInfoItem(
+                item: DeviceInfoItem(
+                    label: "Mobile network technologies",
+                    value: .info(mobileNetworkTechnologies.description)
+                ),
+                stabilityLevel: .unique,
+                versions: .since(.v6)
+            ),
         ]
     }
 }

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/CellularNetworkInfoHarvester.swift
@@ -6,6 +6,7 @@ import CoreTelephony
 protocol CellularNetworkInfoHarvesting {
     var mobileCountryCodes: [String] { get }
     var mobileNetworkCodes: [String] { get }
+    var mobileNetworkTechnologies: [String] { get }
 }
 
 @available(tvOS, unavailable)
@@ -28,6 +29,7 @@ extension CellularNetworkInfoHarvester {
     #else
     private struct CellularServiceInfoProviderFake: CellularServiceInfoProviding {
         var cellularProviders: [CarrierInfoProviding] { [] }
+        var radioAccessTechnologies: [String] { [] }
     }
 
     init() {
@@ -49,6 +51,12 @@ extension CellularNetworkInfoHarvester: CellularNetworkInfoHarvesting {
         cellularServiceInfoProvider
             .cellularProviders
             .compactMap(\.mobileNetworkCode)
+            .sorted()
+    }
+
+    var mobileNetworkTechnologies: [String] {
+        cellularServiceInfoProvider
+            .radioAccessTechnologies
             .sorted()
     }
 }

--- a/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CellularServiceInfoProviding.swift
+++ b/Sources/FingerprintJS/Harvesters/CellularNetworkInfoHarvester/Providers/CellularServiceInfoProviding.swift
@@ -5,6 +5,7 @@ import CoreTelephony
 @available(tvOS, unavailable)
 protocol CellularServiceInfoProviding {
     var cellularProviders: [CarrierInfoProviding] { get }
+    var radioAccessTechnologies: [String] { get }
 }
 
 #if os(iOS)
@@ -12,6 +13,10 @@ extension CTTelephonyNetworkInfo: CellularServiceInfoProviding {
 
     var cellularProviders: [CarrierInfoProviding] {
         serviceSubscriberCellularProviders?.values.compactMap { $0 } ?? []
+    }
+
+    var radioAccessTechnologies: [String] {
+        serviceCurrentRadioAccessTechnology?.values.compactMap { $0 } ?? []
     }
 }
 #endif

--- a/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
+++ b/Sources/FingerprintJS/Harvesters/DataExchange/DeviceInfo.swift
@@ -4,6 +4,7 @@ public struct DeviceInfo: Equatable, Encodable {
     #if os(iOS)
     private let _mobileCountryCodes: [String]
     private let _mobileNetworkCodes: [String]
+    private let _mobileNetworkTechnologies: [String]
     private let _localAuthentication: LocalAuthenticationInfo
     #endif
 
@@ -84,6 +85,13 @@ public struct DeviceInfo: Equatable, Encodable {
         []
         #endif
     }
+    public var mobileNetworkTechnologies: [String] {
+        #if os(iOS)
+        _mobileNetworkTechnologies
+        #else
+        []
+        #endif
+    }
 
     /// The information about the local authentication settings.
     @available(tvOS, unavailable)
@@ -125,6 +133,7 @@ extension DeviceInfo {
         bootTime: String,
         mobileCountryCodes: [String],
         mobileNetworkCodes: [String],
+        mobileNetworkTechnologies: [String],
         localAuthentication: LocalAuthenticationInfo
     ) {
         self.vendorIdentifier = vendorIdentifier
@@ -148,6 +157,7 @@ extension DeviceInfo {
         self.bootTime = bootTime
         self._mobileCountryCodes = mobileCountryCodes
         self._mobileNetworkCodes = mobileNetworkCodes
+        self._mobileNetworkTechnologies = mobileNetworkTechnologies
         self._localAuthentication = localAuthentication
     }
     #endif

--- a/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
+++ b/Sources/FingerprintJS/Library/DeviceInfoProvider.swift
@@ -107,6 +107,7 @@ extension DeviceInfoProvider: DeviceInfoProviding {
             bootTime: osInfoHarvester.bootTime,
             mobileCountryCodes: cellularNetworkInfoHarvester.mobileCountryCodes,
             mobileNetworkCodes: cellularNetworkInfoHarvester.mobileNetworkCodes,
+            mobileNetworkTechnologies: cellularNetworkInfoHarvester.mobileNetworkTechnologies,
             localAuthentication: .init(
                 isPasscodeEnabled: localAuthenticationInfoHarvester.isPasscodeEnabled,
                 isBiometricsEnabled: localAuthenticationInfoHarvester.isBiometricsEnabled,

--- a/Sources/FingerprintJS/Library/FingerprintJSVersion.swift
+++ b/Sources/FingerprintJS/Library/FingerprintJSVersion.swift
@@ -10,11 +10,13 @@ public enum FingerprintJSVersion {
     case v4
     /// Version 5.
     case v5
+    /// Version 6.
+    case v6
 }
 
 extension FingerprintJSVersion {
     /// Latest fingerprint version.
-    public static var latest: Self { .v5 }
+    public static var latest: Self { .v6 }
 }
 
 extension FingerprintJSVersion: CaseIterable, Equatable {}

--- a/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
+++ b/Tests/FingerprintJSTests/FingerprintJSVersionTests.swift
@@ -22,7 +22,7 @@ final class FingerprintJSVersionTests: XCTestCase {
         let versions = [FingerprintJSVersion].since(fromVersion)
 
         // then
-        XCTAssertEqual(versions, [.v2, .v3, .v4, .v5])
+        XCTAssertEqual(versions, [.v2, .v3, .v4, .v5, .v6])
     }
 
     func test_whenAll_thenReturnsAllVersions() {
@@ -30,7 +30,7 @@ final class FingerprintJSVersionTests: XCTestCase {
         let versions = [FingerprintJSVersion].all
 
         // then
-        XCTAssertEqual(versions, [.v1, .v2, .v3, .v4, .v5])
+        XCTAssertEqual(versions, [.v1, .v2, .v3, .v4, .v5, .v6])
     }
 
     func test_whenLatest_thenReturnsVersionFive() {
@@ -38,6 +38,6 @@ final class FingerprintJSVersionTests: XCTestCase {
         let latest = FingerprintJSVersion.latest
 
         // then
-        XCTAssertEqual(latest, .v5)
+        XCTAssertEqual(latest, .v6)
     }
 }

--- a/Tests/FingerprintJSTests/Harvesters/CellularNetworkInfoHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/CellularNetworkInfoHarvesterTests.swift
@@ -122,6 +122,33 @@ final class CellularNetworkInfoHarvesterTests: XCTestCase {
         XCTAssertEqual(1, unknownProvider.mobileNetworkCodeCallCount)
     }
 
+    func test_givenNoRadioAccessTechnologies_whenMobileNetworkTechnologies_thenReturnsEmptyArray() {
+        // given
+        cellularServiceInfoProviderSpy.radioAccessTechnologiesReturnValue = []
+
+        // when
+        let mobileNetworkTechnologies = sut.mobileNetworkTechnologies
+
+        // then
+        XCTAssertTrue(mobileNetworkTechnologies.isEmpty)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.radioAccessTechnologiesCallCount)
+    }
+
+    func test_givenTwoRadioAccessTechnologies_whenMobileNetworkTechnologies_thenReturnsArrayWithTwoElements() {
+        // given
+        cellularServiceInfoProviderSpy.radioAccessTechnologiesReturnValue = [
+            "NetworkTechnology2",
+            "NetworkTechnology1",
+        ]
+
+        // when
+        let mobileNetworkTechnologies = sut.mobileNetworkTechnologies
+
+        // then
+        XCTAssertEqual(["NetworkTechnology1", "NetworkTechnology2"], mobileNetworkTechnologies)
+        XCTAssertEqual(1, cellularServiceInfoProviderSpy.radioAccessTechnologiesCallCount)
+    }
+
     func test_givenConfigurationWithVersionThreeAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
         // given
         let config = Configuration(version: .v3, stabilityLevel: .unique)
@@ -231,6 +258,47 @@ final class CellularNetworkInfoHarvesterTests: XCTestCase {
     }
 
     func test_givenConfigurationWithVersionFiveAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v5, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
+    func test_givenConfigurationWithVersionSixAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v6, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Mobile country codes",
+            "Mobile network codes",
+            "Mobile network technologies",
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionSixAndOptimalStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v6, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
+    func test_givenConfigurationWithVersionSixAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
         // given
         let config = Configuration(version: .v5, stabilityLevel: .stable)
 

--- a/Tests/FingerprintJSTests/Harvesters/IdentifierHarvesterTests.swift
+++ b/Tests/FingerprintJSTests/Harvesters/IdentifierHarvesterTests.swift
@@ -240,6 +240,48 @@ final class IdentifierHarvesterTests: XCTestCase {
         XCTAssertTrue(itemLabels.isEmpty)
     }
 
+    func test_givenConfigurationWithVersionSixAndUniqueStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v6, stabilityLevel: .unique)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Vendor identifier"
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionSixAndOptimalStabilityLevel_whenBuildTree_thenReturnsExpectedItems() {
+        // given
+        let config = Configuration(version: .v6, stabilityLevel: .optimal)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label)
+        let expectedItemLabels = [
+            "Vendor identifier"
+        ]
+        XCTAssertEqual(expectedItemLabels, itemLabels)
+    }
+
+    func test_givenConfigurationWithVersionSixAndStableStabilityLevel_whenBuildTree_thenReturnsNoItems() {
+        // given
+        let config = Configuration(version: .v6, stabilityLevel: .stable)
+
+        // when
+        let itemsTree = sut.buildTree(config)
+
+        // then
+        let itemLabels = itemsTree.children?.map(\.label) ?? []
+        XCTAssertTrue(itemLabels.isEmpty)
+    }
+
     func
         test_givenIdentifierMissingLegacyIdentifierPresent_whenVendorIdentifier_thenMigratesLegacyIdentifierToNewStorage()
     {

--- a/Tests/FingerprintJSTests/TestDoubles/Spies/CellularServiceInfoProvidingSpy.swift
+++ b/Tests/FingerprintJSTests/TestDoubles/Spies/CellularServiceInfoProvidingSpy.swift
@@ -4,11 +4,18 @@
 final class CellularServiceInfoProvidingSpy: CellularServiceInfoProviding {
 
     var cellularProvidersReturnValue: [CarrierInfoProviding] = []
+    var radioAccessTechnologiesReturnValue: [String] = []
 
     private(set) var cellularProvidersCallCount: Int = .zero
+    private(set) var radioAccessTechnologiesCallCount: Int = .zero
 
     var cellularProviders: [CarrierInfoProviding] {
         cellularProvidersCallCount += 1
         return cellularProvidersReturnValue
+    }
+
+    var radioAccessTechnologies: [String] {
+        radioAccessTechnologiesCallCount += 1
+        return radioAccessTechnologiesReturnValue
     }
 }


### PR DESCRIPTION
# Purpose
- Adds `mobileNetworkTechnologies` signal to `CellularNetworkInfoHarvester`.
- Adds `v6` to `FingerprintJSVersion` to incorporate `mobileNetworkTechnologies` into fingerprinting.